### PR TITLE
doc: annotated guide to correctly constraining and optimizing circom

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The circom compiler has an option to look for underconstrained templates and unu
 
 The linked documentation is one of the better guides I've seen on how to guide the compiler how to properly constrain circuits, or else tell the compiler that a signal is unimportant to constrain.
 
-Usage:
+#### Example
 ```sh 
 # with UnusedSignalMultiplier as main
 ❯ mkdir target 
@@ -57,14 +57,15 @@ warning[CA01]: In template "UnderconstrainedMultiplier1()": Local signal a does 
 - run: `circomspect $CIRCUIT_PATH`
     - e.g.: `circomspect circuits/multiplier.circom`. `circomspect` will flag underconstrained templates, but will not flag the overconstrained circuit.
 
-`circomspect` seems powerful and straightforward to use, requiring very little extra context for the developer to use the tool.
+`circomspect` is powerful and straightforward to use, requiring very little extra context for the developer to use the tool.
 
-More about `circomspect` by Trail of Bits, in a few blog posts. These blog posts briefly describe the tool and a few of the passes performed by `circomspect`. They are summaries of the `circomspect` in context, but not important for using the tool.
+More about `circomspect` by Trail of Bits, in a few blog posts. These blog posts briefly describe the tool and a few of the passes performed by `circomspect`. They are summaries of the `circomspect` in context, but are inessential for using the tool.
 - [ToB blog: it pays to be circomspect](https://blog.trailofbits.com/2022/09/15/it-pays-to-be-circomspect/)
 - [ToB blog: circomspect has more passes](https://blog.trailofbits.com/2023/03/21/circomspect-static-analyzer-circom-more-passes/)
 
 It would be good if there were CI to run circomspect, but that does not currently seem to be available. There is no fast way to install circomspect, so it would be slightly costly to run in CI today.
 
+#### Example
 Circomspect produces the following output on `multiplier.circom`:
 ```sh
 ❯ circomspect circuits/multiplier.circom 
@@ -140,7 +141,7 @@ circomspect: 7 issues found.
 ```
 
 ### [circomkit circom testing suite](https://github.com/erhant/circomkit)
-A typescript-based suite of testing tools for circom. The circomkit readme does a better job of summarizing the tool than I could here.
+A typescript-based suite of testing tools for circom. The circomkit README does a better job of summarizing the tool than I could here.
 
 Circomkit theoretically could be used to [test passing and failing witnesses](https://github.com/erhant/circomkit?tab=readme-ov-file#witness-tester) for circuits, though this seems inelegant as provided, and seems really only designed for one-off soundness checks.
 
@@ -150,11 +151,11 @@ See the [short circomkit usage example in this repo](https://github.com/pluto/ci
 The following tools were examined and found eclipsed in utility by other tools (circomscribe), failed to build (picus), or exceedingly complex to understand [(circom-mutator)](https://github.com/aviggiano/circom-mutator).
 
 ### [zksecurity circomscribe - demo playground, visualize constraints ](https://www.circomscribe.dev/)
-Circomscribe is the circom compiler, run in WASM in the browser in an online playground tool. The tool emits information about the circom compilation process. This is a clunky workflow, copy pasting code into a browser. 
+Circomscribe is the circom compiler, run in WASM in the browser in an online playground tool. The tool emits information about the circom compilation process. This is a clunky workflow, pasting code into a browser. 
 
 The main context where this tool could be useful would be to see explicitly what constraints are produced by circom snippet, which could be useful for obtaining greater granularity of depth. This tool would be annoying to use if the template had more than one or two dependency templates.
 
-Run on each of the multipliers in `circuits/multiplier.circom`, Circomscribe produces the following outputs. Note that the underconstrained circuits each only have 1 line of constraint rather than 2.
+Run on each of the multipliers in `circuits/multiplier.circom`, Circomscribe produces the following outputs. Note that the underconstrained circuits each only have 1 line of constraint, rather than 2.
 ```sh
 (- 1 * Multiplier.a )*(Multiplier.b ) = - 1 * Multiplier.intermediary
 - 1 * Multiplier.c + Multiplier.intermediary = 0
@@ -185,7 +186,7 @@ It could be worthwhile to come back and try to get this tool to work, but it's h
 
 ## Everything you should know about correctly assigning constraints
 
-### the basics
+### The basics
 Circom allows the developer to specify constraints in two ways:
 ```rust
 // 1. equality constraint operators: ===, <==, ==> 
@@ -211,13 +212,13 @@ a2 <== a*a;
 a2*a === b; // equivalently, assert(a2*a == b);
 ```
 
-### when may a developer choose to use `<--` assignment over `<==`?
+### When may a developer choose to use `<--` assignment over `<==`?
 > assigning a value to a signal using <-- and --> is considered dangerous and should, in general, be combined with adding constraints with \=\=\=, which describe by means of constraints which the assigned values are. 
 > https://docs.circom.io/circom-language/constraint-generation/
 
-As stated in the circom docs, generally avoid using `<--`, at least until an optimization code pass. The operator may save a small number of gates, but risks underconstraining the circuit. A developer may incorrectly use `<--` to allow assignment for would-be non-quadratic assignments; this is a [footgun](https://en.wiktionary.org/wiki/footgun).
+As stated in the circom docs, generally avoid using `<--`, at least until an optimization code pass. The operator may save a few gates, but risks underconstraining the circuit. A developer may incorrectly use `<--` to allow assignment for would-be non-quadratic assignments; this is a [footgun](https://en.wiktionary.org/wiki/footgun).
 
-Use of `<--` is can allow the developer to reason extra constraints out of their circuits, thereby improving proving times. When optimizing code with `<--`, use tools like `circom --inspect` (which searches the codebase for `<--` that can be transformed into `<==`) and `circomspect` to check for correctly constrained circuits.
+Use of `<--` allows the developer to reason extra constraints out of their circuits, thereby improving proving times. When optimizing code with `<--`, use tools like `circom --inspect` (which searches the codebase for `<--` that can be transformed into `<==`) and `circomspect` to check for correctly constrained circuits.
 
 Documentation as to how to correctly use `<--` is sparse, but as best as this author can infer, there are essentially two reasons to use assignment without assertion:
 1. **avoid unnecessary constraints on intermediate calculations**
@@ -226,7 +227,7 @@ Documentation as to how to correctly use `<--` is sparse, but as best as this au
 
 Two examples applying `<--` are given in the [circom documentation](https://docs.circom.io/circom-language/basic-operators/#examples-using-operators-from-the-circom-library).
 
-#### circom docs example 1: avoid unnecessary constraints on intermediate calculations
+#### Circom docs example 1: avoid unnecessary constraints on intermediate calculations
 ```rust
 pragma circom 2.0.0;
 
@@ -251,7 +252,7 @@ Which can be expressed in two constraints; assigning a value to `out` from the v
 
 The value of `inv` is an intermediate calculation, and does not require a constraint.
 
-#### circom docs example 2: check a more general constraint, and defer constraint checks
+#### Circom docs example 2: check a more general constraint, and defer constraint checks
 ```rust
 pragma circom 2.0.0;
 
@@ -282,7 +283,7 @@ That is, the constraints for this template can be specified more succinctly than
 - `out[i]` is binary (this could be stated even more succinctly with the `binary` tag in circom 2.1.0) 
 - `out`'s assignments are accumulated in var `lc1`, which is value-checked at template's end.
 
-#### example 3: further examples
+#### Example 3: further examples
 ```rust
 template QuadraticIntermediate() {
     // Intermediate calculations
@@ -318,20 +319,23 @@ template IsEven() {
 }
 ```
 
-## further reading about underconstrained circuits
+### Common mistakes in underconstraining circuits
+I was originally going to close with a section on common oversights in underconstrained circuits, but other resources have already done this well. I direct the reader toward the [0xPARC ZK bug tracker](https://github.com/0xPARC/zk-bug-tracker) in particular, an index of zk bugs in discovered in the wild, and a list of common oversights in constraining circuits, and Erhant's [circom101 book](https://circom.erhant.me/), which provides further examples of optimized and constrained circuits.
+
+## Further Reading 
 The following resources may provide further direction in writing correctly constrained Circom. 
 
-### recommended short reading
+### Recommended short reading
 - [0xPARC ZK bug tracker](https://github.com/0xPARC/zk-bug-tracker) - a list of bugs and exploits found in zk applications. The list of [common vulnerabilities](https://github.com/0xPARC/zk-bug-tracker?tab=readme-ov-file#common-vulnerabilities-1) is particularly worth reviewing.
 - [Circom constraint generation docs](https://docs.circom.io/circom-language/constraint-generation/) - an introduction to how constraints are generated; overlaps with the *basics* section given above.
-- [Circom Anonymous Component documentation](https://docs.circom.io/circom-language/anonymous-components-and-tuples) - Circom 2.1.0 introduced anonymous components. These allow for significantly more concise and expressive syntax in declaring components, reducing risk of developer error.
+- [Circom Anonymous Component documentation](https://docs.circom.io/circom-language/anonymous-components-and-tuples) - Circom 2.1.0 introduced anonymous components. While not directly related to circuit constraints, anonymous components allow for significantly more concise and expressive syntax in declaring components, reducing risk of developer error (i.e. the developer may incur less brain damage from writing Circom, the author recommends this)
 
-### recommended longer reading
+### Recommended longer reading
 - [circom101 book by erhant, author of circomkit](https://circom.erhant.me/) - Erhant's book is good supplementary material for the circom documentation, and details the implementation of several optimized circom templates.
 - [0xPARC: circom workshop series](https://learn.0xparc.org/materials/circom/learning-group-1/intro-zkp) - a series of videos on zero knowledge generally, and circom in particular
 
-### also reviewed in preparation for this post
-To save the reader some time in exploring resources, these posts were reviewed in preparation for this post and are briefly summarized for completess, but are not recommended reading.
+### Also reviewed in preparation for this post
+To save the reader some time in exploring resources, these posts were reviewed in preparation for this post and are briefly summarized for completeness, but are not recommended reading.
 
 - [dacian: exploiting under-constrained zk circuits](https://dacian.me/exploiting-under-constrained-zk-circuits) - a walkthrough of correctly constraining a circom template that a value is not prime. Examples provided for:
     - asserting inputs values are not equal to one


### PR DESCRIPTION
Adds short blog post in README about correctly constraining Circom values.
